### PR TITLE
Added gir1.2-notify to the Dependencies in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These are:
 - libqt4-sql-sqlite
 - python-pyside
 - gir1.2-unity
+- gir1.2-notify
 - maybe something more, let me know
 
 ## How to run it?


### PR DESCRIPTION
hey, Michał,
yeap! gir1.2-notify is needed in Zeegaree, too. (when i apt-get remove'd it, i got the same error from Zeegaree that I had gotten from Zeegaree-Lite.  (again, my system is 15.04).  when i re-installed the gir1.2-notify package, Zeegaree worked again.
Jeff
